### PR TITLE
Added support for v6e

### DIFF
--- a/tpu_info/pyproject.toml
+++ b/tpu_info/pyproject.toml
@@ -17,7 +17,7 @@ requires = ["hatchling", "hatch-build-scripts", "grpcio-tools~=1.65.5"]
 build-backend = "hatchling.build"
 
 [project]
-version = "0.1.0"
+version = "0.1.1"
 name = "tpu-info"
 dependencies = [
   # `grpcio` should match `grpcio-tools` build dependency

--- a/tpu_info/tpu_info/device.py
+++ b/tpu_info/tpu_info/device.py
@@ -41,7 +41,7 @@ class TpuChip(enum.Enum):
   V4 = Info("v4", hbm_gib=32, devices_per_chip=1)
   V5E = Info("v5e", hbm_gib=16, devices_per_chip=1)
   V5P = Info("v5p", hbm_gib=95, devices_per_chip=1)
-  V6E = Info("v6e", hbm_gib=32, devices_per_chip=1) #TODO: Check if devices per chip is correct
+  V6E = Info("v6e", hbm_gib=32, devices_per_chip=1)
 
   @classmethod
   def from_pci_device_id(

--- a/tpu_info/tpu_info/device.py
+++ b/tpu_info/tpu_info/device.py
@@ -41,6 +41,7 @@ class TpuChip(enum.Enum):
   V4 = Info("v4", hbm_gib=32, devices_per_chip=1)
   V5E = Info("v5e", hbm_gib=16, devices_per_chip=1)
   V5P = Info("v5p", hbm_gib=95, devices_per_chip=1)
+  V6E = Info("v6e", hbm_gib=32, devices_per_chip=1) #TODO: Check if devices per chip is correct
 
   @classmethod
   def from_pci_device_id(
@@ -58,6 +59,7 @@ class TpuChip(enum.Enum):
         "0x005e": cls.V4,
         "0x0063": cls.V5E,
         "0x0062": cls.V5P,
+        "0x006f": cls.V6E,
     }
 
     return device_id_to_device.get(device_id)
@@ -91,7 +93,7 @@ def get_local_chips() -> Tuple[Optional[TpuChip], int]:
 
 def chip_path(chip_type: TpuChip, index: int):
   """Returns the expected `/dev` path for a given TPU device type."""
-  if chip_type in [TpuChip.V5E, TpuChip.V5P]:
+  if chip_type in [TpuChip.V5E, TpuChip.V5P, TpuChip.V6E]:
     return f"/dev/vfio/{index}"
   else:
     return f"/dev/accel{index}"


### PR DESCRIPTION
Currently trillium machines are not supported on tpu-info

I used the information at [jax hardware utils file](https://github.com/google/jax/blob/8a8f74663ffcf494420fbff8687d85cd76dad7e7/jax/_src/hardware_utils.py#L31) to fill in the information required for this script to work

I also increased the version to ensure all new and old users will be updated, so the experience will be smooth and great